### PR TITLE
PEP8: E265 block comment should start with '# '

### DIFF
--- a/autogen/autogen.js
+++ b/autogen/autogen.js
@@ -17,7 +17,7 @@ var autogenFenceComments = {
     '.md': { start: /<!--\s*~autogen *([\w-]+) *((\s*[\w\."']+>[\w\.]+)*)\s*-->/, end: "<!-- ~autogen -->" },
     //Lua regex: http://regex101.com/r/mI4gL1
     '.lua': { start: /-- *~autogen *([\w-]+) *((\s*[\w\."']+>[\w\.]+)*)/, end: "-- ~autogen" },
-    '.py': { start: /#~autogen *([\w-]+) *((\s*[\w\."']+>[\w\.]+)*)/, end: "#~autogen" }
+    '.py': { start: /# ~autogen *([\w-]+) *((\s*[\w\."']+>[\w\.]+)*)/, end: "# ~autogen" }
 }
 
 //Extension and helper methods


### PR DESCRIPTION
I've installed [pep8](http://github.com/jcrocholl/pep8/) tool that checks python files for conformance to the style guide. This PR is the outcome.